### PR TITLE
Add a README

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.2.0"
 authors = ["Josh Matthews <josh@joshmatthews.net>"]
 license = "MPL-2.0"
 description = "A library for parsing Safari-style content blocking lists and dynamically evaluating the rules against against requests."
-repository = "https://github.com/jdm/content-blocker"
+repository = "https://github.com/servo/content-blocker"
 
 [dependencies]
 serde_json = "0.7"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+Content-blocker
+---------------
+
+A library for parsing Safari-style content blocking lists and dynamically
+evaluating the rules against against requests.
+
+Want to help out? See [the Servo contributing
+guide](https://github.com/servo/servo/blob/master/CONTRIBUTING.md)


### PR DESCRIPTION
and update the URL in cargo.toml, since it looks like this repo got moved from jdm to the servo org
